### PR TITLE
Container and sensor page. Delete container and sensor.

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@heroicons/react": "^2.0.16",
     "@hookform/resolvers": "^3.0.0",
     "@mapbox/mapbox-gl-geocoder": "^5.0.1",
+    "@radix-ui/react-alert-dialog": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.4",
     "@radix-ui/react-label": "^2.0.1",

--- a/apps/web/src/hooks/forms/useCreateSensorForm.ts
+++ b/apps/web/src/hooks/forms/useCreateSensorForm.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { z } from "zod";
 import { useToast } from "../toast/useToast";
 import useZodForm from "../useZodForm";
+import { useRouter } from "next/router";
 
 type CreateSensorFormProps = {
   sensorId: string;
@@ -23,6 +24,7 @@ const useCreateSensorForm = ({
   latitude,
   longitude,
 }: CreateSensorFormProps) => {
+  const router = useRouter();
   const { mutateAsync } = trpc.sensor.create.useMutation({
     onSuccess: () => {
       toast({
@@ -30,6 +32,8 @@ const useCreateSensorForm = ({
         description: "Successfully added sensor.",
         severity: "success",
       });
+
+      router.push("/");
     },
     onError: (error) => {
       toast({

--- a/apps/web/src/hooks/map/useAllSensorsMap.tsx
+++ b/apps/web/src/hooks/map/useAllSensorsMap.tsx
@@ -48,7 +48,12 @@ const useAllSensorsMap = () => {
         // Render custom popup content
         const popupNode = document.createElement("div");
         ReactDOM.render(
-          <SensorMarkerPopover title={sensor.name} content={sensor.location} link={`sensors/${sensor.id}`} linkContent="See more"/>,
+          <SensorMarkerPopover
+            title={sensor.name}
+            content={sensor.location}
+            link={`sensors/${sensor.id}`}
+            linkLabel="See more"
+          />,
           popupNode,
         );
         const popup = MapboxPopup({ html: popupNode });

--- a/apps/web/src/hooks/map/useAllSensorsMap.tsx
+++ b/apps/web/src/hooks/map/useAllSensorsMap.tsx
@@ -48,7 +48,7 @@ const useAllSensorsMap = () => {
         // Render custom popup content
         const popupNode = document.createElement("div");
         ReactDOM.render(
-          <SensorMarkerPopover title={sensor.name} content={sensor.location} />,
+          <SensorMarkerPopover title={sensor.name} content={sensor.location} link={`sensors/${sensor.id}`} linkContent="See more"/>,
           popupNode,
         );
         const popup = MapboxPopup({ html: popupNode });

--- a/apps/web/src/hooks/queries/useGetContainer.ts
+++ b/apps/web/src/hooks/queries/useGetContainer.ts
@@ -1,6 +1,5 @@
 import { trpc } from "@/utils/trpc";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
 import { useToast } from "../toast/useToast";
 
 type GetContainerProps = {
@@ -10,25 +9,26 @@ type GetContainerProps = {
 const useGetContainer = ({ id }: GetContainerProps) => {
   const router = useRouter();
   const { toast } = useToast();
-  const { data, isLoading, error } = trpc.container.get.useQuery({
-    containerId: id,
-  });
+  const { data, isLoading, error } = trpc.container.get.useQuery(
+    {
+      containerId: id,
+    },
 
-  useEffect(() => {
-    if (error) {
-      toast({
-        title: "Oops!",
-        description: `An error occurred: ${error.message}`,
-        severity: "error",
-      });
-    }
-  }, [error, toast]);
+    {
+      onError: (err) => {
+        if (err.data?.code === "NOT_FOUND") {
+          router.push("/404");
+          return;
+        }
 
-  useEffect(() => {
-    if (error?.data?.code === "NOT_FOUND") {
-      router.push("/404");
-    }
-  }, [error, router]);
+        toast({
+          title: "Error!",
+          description: "There was an error while fetching the container",
+          severity: "error",
+        });
+      },
+    },
+  );
 
   return {
     data,

--- a/apps/web/src/hooks/queries/useGetContainerWithSensors.ts
+++ b/apps/web/src/hooks/queries/useGetContainerWithSensors.ts
@@ -1,6 +1,7 @@
 import { trpc } from "@/utils/trpc";
 import { useRouter } from "next/router";
 import { toast } from "../toast/useToast";
+import { error } from "console";
 
 type GetContainerWithSensorsProps = {
   id: string;
@@ -14,8 +15,17 @@ const useGetContainerWithSensors = ({ id }: GetContainerWithSensorsProps) => {
         containerId: id,
       },
       {
-        onError: () => {
-          router.push("/404");
+        onError: (err) => {
+          if (err.data?.code === "NOT_FOUND") {
+            router.push("/404");
+            return;
+          }
+
+          toast({
+            title: "Error!",
+            description: "There was an error while fetching the container",
+            severity: "error",
+          });
         },
       },
     );

--- a/apps/web/src/hooks/queries/useGetContainerWithSensors.ts
+++ b/apps/web/src/hooks/queries/useGetContainerWithSensors.ts
@@ -1,7 +1,6 @@
 import { trpc } from "@/utils/trpc";
 import { useRouter } from "next/router";
 import { toast } from "../toast/useToast";
-import { error } from "console";
 
 type GetContainerWithSensorsProps = {
   id: string;

--- a/apps/web/src/hooks/queries/useGetContainerWithSensors.ts
+++ b/apps/web/src/hooks/queries/useGetContainerWithSensors.ts
@@ -1,0 +1,72 @@
+import { trpc } from "@/utils/trpc";
+import { useRouter } from "next/router";
+import { toast } from "../toast/useToast";
+
+type GetContainerWithSensorsProps = {
+  id: string;
+};
+
+const useGetContainerWithSensors = ({ id }: GetContainerWithSensorsProps) => {
+  const router = useRouter();
+  const { data: container, isLoading: containerIsLoading } =
+    trpc.container.get.useQuery(
+      {
+        containerId: id,
+      },
+      {
+        onError: () => {
+          router.push("/404");
+        },
+      },
+    );
+  const { data: sensors, isLoading: sensorsIsLoading } =
+    trpc.container.getSensorsByContainerId.useQuery(
+      {
+        containerId: id,
+      },
+      {
+        onError: () => {
+          toast({
+            title: "Error!",
+            description: "There was an error while fetching the sensors",
+            severity: "error",
+          });
+        },
+      },
+    );
+
+  const {
+    mutateAsync: deleteContainerMutation,
+    isLoading: deleteContainerIsLoading,
+  } = trpc.container.delete.useMutation({
+    onSuccess: () => {
+      toast({
+        title: "Success!",
+        description:
+          "Container was deleted. You will now be redirected to the dashboard",
+        severity: "success",
+      });
+
+      router.push("/");
+    },
+    onError: () => {
+      toast({
+        title: "Error!",
+        description: "There was an error while deleting the container",
+        severity: "error",
+      });
+    },
+  });
+
+  const loading =
+    containerIsLoading || sensorsIsLoading || deleteContainerIsLoading;
+
+  return {
+    container,
+    sensors,
+    loading,
+    deleteContainerMutation,
+  };
+};
+
+export default useGetContainerWithSensors;

--- a/apps/web/src/hooks/queries/useGetSensor.ts
+++ b/apps/web/src/hooks/queries/useGetSensor.ts
@@ -8,7 +8,11 @@ type GetSensorProps = {
 
 const useGetSensor = ({ id }: GetSensorProps) => {
   const router = useRouter();
-  const { data, isLoading: sensorIsLoading } = trpc.sensor.get.useQuery(
+  const {
+    data,
+    isLoading: sensorIsLoading,
+    error,
+  } = trpc.sensor.get.useQuery(
     { id },
     {
       onError: (err) => {
@@ -54,6 +58,7 @@ const useGetSensor = ({ id }: GetSensorProps) => {
   return {
     data,
     isLoading,
+    error,
     deleteSensorMutation,
   };
 };

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -1,110 +1,53 @@
-import { toast } from "@/hooks/toast/useToast";
 import { Button } from "@/ui/Button";
 import H1 from "@/ui/typography/H1";
-import Subtle from "@/ui/typography/Subtle";
-import { trpc } from "@/utils/trpc";
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { Textarea } from "@/ui/Textarea";
 import H4 from "@/ui/typography/H4";
-import LoadingSpinner from "@/ui/LoadingSpinner";
 import Alert from "@/ui/Alert";
 import { PencilIcon, TrashIcon } from "@heroicons/react/24/outline";
+import useGetContainerWithSensors from "@/hooks/queries/useGetContainerWithSensors";
+import LoadingSpinner from "@/ui/LoadingSpinner";
 
 type ContainerPageProps = InferGetServerSidePropsType<
   typeof getServerSideProps
 >;
 
 const ContainerPage = ({ id }: ContainerPageProps) => {
-  const router = useRouter();
-
-  const {
-    data: container,
-    isLoading: containerIsLoading,
-    error: containerError,
-  } = trpc.container.get.useQuery({
-    containerId: id,
-  });
-  const {
-    data: sensors,
-    isLoading: sensorsIsLoading,
-    error: sensorsError,
-  } = trpc.container.getSensorsByContainerId.useQuery({
-    containerId: id,
-  });
-  const {
-    mutate: deleteContainer,
-    isLoading: deleteContainerIsLoading,
-    error: deleteContainerError,
-  } = trpc.container.delete.useMutation();
-
-  if (containerIsLoading || sensorsIsLoading || deleteContainerIsLoading) {
-    return <LoadingSpinner />;
-  }
-
-  if (containerError || sensorsError || deleteContainerError) {
-    return <div>Error</div>;
-  }
-
-  if (!container) {
-    return (
-      <div className="flex flex-col items-center justify-center gap-y-4">
-        <H1>Oh no!</H1>
-        <Subtle>
-          It looks like the container you&apos;re looking for doesn&apos;t
-          exist.
-        </Subtle>
-        <Link href="/">
-          <Button variant="subtle">Return home</Button>
-        </Link>
-      </div>
-    );
-  }
+  const { container, sensors, loading, deleteContainerMutation } =
+    useGetContainerWithSensors({ id });
 
   const onDelete = async () => {
-    try {
-      await deleteContainer({ containerId: id });
-      toast({
-        title: "Success!",
-        description:
-          "Container was deleted. You will now be redirected to the dashboard",
-        severity: "success",
-      });
-      router.push({
-        pathname: "/",
-      });
-    } catch (error) {
-      toast({
-        title: "Error!",
-        description: "There was an error while deleting the container",
-        severity: "error",
-      });
-    }
+    await deleteContainerMutation({ containerId: id });
   };
 
   // TODO: change textarea with card from tremor
   return (
     <div>
-      <H1>{container.name}</H1>
+      {loading && <LoadingSpinner />}
+      <H1>{container?.name}</H1>
       <div className="items-left justify-left my-4 flex flex-col">
         <H4>Height</H4>
-        <p>{container.binHeightInMillimeters}</p>
+        <p>{container?.binHeightInMillimeters}</p>
         <H4>Width</H4>
-        <p>{container.binWidthInMillimeters}</p>
+        <p>{container?.binWidthInMillimeters}</p>
         <H4>Volume</H4>
-        <p>{container.containerVolumeInLiters}</p>
+        <p>{container?.containerVolumeInLiters}</p>
         <H4>Description</H4>
-        <Textarea value={container.description} disabled />
+        <Textarea value={container?.description} disabled />
         <H4>Sensors:</H4>
         <ul className="ml-8 list-disc">
-          {sensors.map((sensor) => (
-            <li key={sensor.id}>
-              <Link className="hover:underline" href={`/sensors/${sensor.id}`}>
-                {sensor.name}
-              </Link>
-            </li>
-          ))}
+          {sensors &&
+            sensors.map((sensor) => (
+              <li key={sensor.id}>
+                <Link
+                  className="hover:underline"
+                  href={`/sensors/${sensor.id}`}
+                >
+                  {sensor.name}
+                </Link>
+              </li>
+            ))}
         </ul>
       </div>
       <div className="items-left justify-left my-4 flex flex-row gap-x-4">
@@ -119,8 +62,8 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
         </Link>
 
         <Alert
-          title="Are you sure you want to delete the container?"
-          description="The container will be deleted, and removed from all sensors that are currently using it."
+          title="Are you sure you want to delete the container??"
+          description="The container? will be deleted, and removed from all sensors that are currently using it."
           trigger={
             <Button
               variant="subtle"

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -1,6 +1,9 @@
+import { Button } from "@/ui/Button";
 import H1 from "@/ui/typography/H1";
+import Subtle from "@/ui/typography/Subtle";
 import { trpc } from "@/utils/trpc";
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
+import Link from "next/link";
 
 type ContainerPageProps = InferGetServerSidePropsType<
   typeof getServerSideProps
@@ -31,14 +34,24 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
   }
 
   if (!container) {
-    return <div>Container not found</div>;
+    return     <div className="flex flex-col items-center justify-center gap-y-4">
+    <H1>Oh no!</H1>
+    <Subtle>
+      It looks like the container you&apos;re looking for doesn&apos;t exist.
+    </Subtle>
+    <Link href="/">
+      <Button variant="subtle">Take me home</Button>
+    </Link>
+  </div>;
   }
 
   return (
     <div>
-      <H1>Container {container.id}</H1>
+      <H1>{container.name}</H1>
+      <p>Height: {container.binHeightInMillimeters}</p>
+      <p>Width: {container.binWidthInMillimeters}</p>
+      <p>Volume: {container.containerVolumeInLiters}</p>
       <p>Description: {container.description}</p>
-      <p>Name: {container.name}</p>
       <p>Sensors:</p>
       <ul>
         {sensors.map((sensor) => (

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -17,6 +17,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/ui/AlertDialog"
+import { Textarea } from "@/ui/Textarea";
+import H4 from "@/ui/typography/H4";
 
 type ContainerPageProps = InferGetServerSidePropsType<
   typeof getServerSideProps
@@ -89,30 +91,41 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
   </div>;
   }
 
+  //TODO change textarea with card from tremor
   return (
     <div>
       <H1>{container.name}</H1>
-      <p>Height: {container.binHeightInMillimeters}</p>
-      <p>Width: {container.binWidthInMillimeters}</p>
-      <p>Volume: {container.containerVolumeInLiters}</p>
-      <p>Description: {container.description}</p>
-      <p>Sensors:</p>
-      <ul>
+      <div className="my-4 flex flex-col items-left justify-left">
+      <H4>Height</H4>
+      <p>{container.binHeightInMillimeters}</p>
+      <H4>Width</H4>
+      <p>{container.binWidthInMillimeters}</p>
+      <H4>Volume</H4>
+      <p>{container.containerVolumeInLiters}</p>
+      <H4>Description</H4>
+      <Textarea value={container.description} disabled />
+      <H4>Sensors:</H4>
+      <ul className="list-disc ml-8">
         {sensors.map((sensor) => (
           <li key={sensor.id}>
             {sensor.name} 
           </li>
         ))}
       </ul>
+    </div>
+    <div className="my-4 flex flex-row items-left justify-left gap-x-4">
+      <Link href={`${id}/update`}>
+      <Button variant="subtle">Update</Button>
+    </Link>
       <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant="outline">Delete Container</Button>
+        <Button variant="subtle">Delete</Button>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
           <AlertDialogDescription>
-            Once executed, this action cannot be reversed. It will permanently delete the container and remove it from all sensors that are currently using it.
+            Once executed, this action cannot be reversed. It will permanently delete this container and remove it from all sensors that are currently using it.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -121,6 +134,7 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+    </div>
     </div>
   );
 };

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -6,29 +6,19 @@ import { trpc } from "@/utils/trpc";
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/ui/AlertDialog"
 import { Textarea } from "@/ui/Textarea";
 import H4 from "@/ui/typography/H4";
 import LoadingSpinner from "@/ui/LoadingSpinner";
+import DeleteContainerAlert from "@/ui/containers/DeleteContainerAlert";
+import { PencilIcon, TrashIcon } from "@heroicons/react/24/outline";
 
 type ContainerPageProps = InferGetServerSidePropsType<
   typeof getServerSideProps
 >;
 
 const ContainerPage = ({ id }: ContainerPageProps) => {
-
   const router = useRouter();
-  
+
   const {
     data: container,
     isLoading: containerIsLoading,
@@ -49,7 +39,6 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
     error: deleteContainerError,
   } = trpc.container.delete.useMutation();
 
-
   if (containerIsLoading || sensorsIsLoading || deleteContainerIsLoading) {
     return <LoadingSpinner />;
   }
@@ -57,25 +46,29 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
   if (containerError || sensorsError || deleteContainerError) {
     return <div>Error</div>;
   }
-  
+
   if (!container) {
-    return     <div className="flex flex-col items-center justify-center gap-y-4">
-    <H1>Oh no!</H1>
-    <Subtle>
-      It looks like the container you&apos;re looking for doesn&apos;t exist.
-    </Subtle>
-    <Link href="/">
-      <Button variant="subtle">Return home</Button>
-    </Link>
-  </div>;
+    return (
+      <div className="flex flex-col items-center justify-center gap-y-4">
+        <H1>Oh no!</H1>
+        <Subtle>
+          It looks like the container you&apos;re looking for doesn&apos;t
+          exist.
+        </Subtle>
+        <Link href="/">
+          <Button variant="subtle">Return home</Button>
+        </Link>
+      </div>
+    );
   }
 
-  const handleDelete = async () => {
+  const onDelete = async () => {
     try {
       await deleteContainer({ containerId: id });
       toast({
         title: "Success!",
-        description: "Container was deleted. You will now be redirected to the dashboard",
+        description:
+          "Container was deleted. You will now be redirected to the dashboard",
         severity: "success",
       });
       router.push({
@@ -88,52 +81,59 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
         severity: "error",
       });
     }
-  };  
+  };
 
-  //TODO change textarea with card from tremor
+  // TODO: change textarea with card from tremor
   return (
     <div>
       <H1>{container.name}</H1>
-      <div className="my-4 flex flex-col items-left justify-left">
-      <H4>Height</H4>
-      <p>{container.binHeightInMillimeters}</p>
-      <H4>Width</H4>
-      <p>{container.binWidthInMillimeters}</p>
-      <H4>Volume</H4>
-      <p>{container.containerVolumeInLiters}</p>
-      <H4>Description</H4>
-      <Textarea value={container.description} disabled />
-      <H4>Sensors:</H4>
-      <ul className="list-disc ml-8">
-        {sensors.map((sensor) => (
-          <li key={sensor.id}>
-            <Link className="hover:underline" href={`../sensors/${sensor.id}`}>{sensor.name}</Link>
-          </li>
-        ))}
-      </ul>
-    </div>
-    <div className="my-4 flex flex-row items-left justify-left gap-x-4">
-      <Link href={`${id}/update`}>
-      <Button variant="subtle">Update</Button>
-    </Link>
-      <AlertDialog>
-      <AlertDialogTrigger asChild>
-        <Button variant="subtle">Delete</Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-          <AlertDialogDescription>
-            Once executed, this action cannot be reversed. It will permanently delete this container and remove it from all sensors that are currently using it.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={handleDelete}>Continue</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-    </div>
+      <div className="items-left justify-left my-4 flex flex-col">
+        <H4>Height</H4>
+        <p>{container.binHeightInMillimeters}</p>
+        <H4>Width</H4>
+        <p>{container.binWidthInMillimeters}</p>
+        <H4>Volume</H4>
+        <p>{container.containerVolumeInLiters}</p>
+        <H4>Description</H4>
+        <Textarea value={container.description} disabled />
+        <H4>Sensors:</H4>
+        <ul className="ml-8 list-disc">
+          {sensors.map((sensor) => (
+            <li key={sensor.id}>
+              <Link
+                className="hover:underline"
+                href={`/dashboard/sensors/${sensor.id}`}
+              >
+                {sensor.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="items-left justify-left my-4 flex flex-row gap-x-4">
+        <Link href={`/dashboard/containers/${id}/update`}>
+          <Button
+            variant="subtle"
+            className="flex items-center justify-center gap-x-2"
+          >
+            <PencilIcon className="w-4" />
+            <span>Update</span>
+          </Button>
+        </Link>
+
+        <DeleteContainerAlert
+          trigger={
+            <Button
+              variant="subtle"
+              className="flex items-center justify-center gap-x-2"
+            >
+              <TrashIcon className="w-4" />
+              <span>Delete</span>
+            </Button>
+          }
+          onDelete={onDelete}
+        />
+      </div>
     </div>
   );
 };
@@ -142,6 +142,7 @@ export const getServerSideProps = async (
   context: GetServerSidePropsContext<{ id: string }>,
 ) => {
   const id = context.params?.id;
+
   if (!id) {
     return {
       redirect: {

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -25,57 +25,61 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
   return (
     <div>
       {loading && <LoadingSpinner />}
-      <H1>{container?.name}</H1>
-      <div className="items-left justify-left my-4 flex flex-col">
-        <H4>Height</H4>
-        <p>{container?.binHeightInMillimeters}</p>
-        <H4>Width</H4>
-        <p>{container?.binWidthInMillimeters}</p>
-        <H4>Volume</H4>
-        <p>{container?.containerVolumeInLiters}</p>
-        <H4>Description</H4>
-        <Textarea value={container?.description} disabled />
-        <H4>Sensors:</H4>
-        <ul className="ml-8 list-disc">
-          {sensors &&
-            sensors.map((sensor) => (
-              <li key={sensor.id}>
-                <Link
-                  className="hover:underline"
-                  href={`/sensors/${sensor.id}`}
-                >
-                  {sensor.name}
-                </Link>
-              </li>
-            ))}
-        </ul>
-      </div>
-      <div className="items-left justify-left my-4 flex flex-row gap-x-4">
-        <Link href={`/containers/${id}/update`}>
-          <Button
-            variant="subtle"
-            className="flex items-center justify-center gap-x-2"
-          >
-            <PencilIcon className="w-4" />
-            <span>Update</span>
-          </Button>
-        </Link>
+      {!loading && container && (
+        <div className="flex flex-col items-center justify-center">
+          <H1>{container?.name}</H1>
+          <div className="items-left justify-left my-4 flex flex-col">
+            <H4>Height</H4>
+            <p>{container?.binHeightInMillimeters}</p>
+            <H4>Width</H4>
+            <p>{container?.binWidthInMillimeters}</p>
+            <H4>Volume</H4>
+            <p>{container?.containerVolumeInLiters}</p>
+            <H4>Description</H4>
+            <Textarea value={container?.description} disabled />
+            <H4>Sensors:</H4>
+            <ul className="ml-8 list-disc">
+              {sensors &&
+                sensors.map((sensor) => (
+                  <li key={sensor.id}>
+                    <Link
+                      className="hover:underline"
+                      href={`/sensors/${sensor.id}`}
+                    >
+                      {sensor.name}
+                    </Link>
+                  </li>
+                ))}
+            </ul>
+          </div>
+          <div className="items-left justify-left my-4 flex flex-row gap-x-4">
+            <Link href={`/containers/${id}/update`}>
+              <Button
+                variant="subtle"
+                className="flex items-center justify-center gap-x-2"
+              >
+                <PencilIcon className="w-4" />
+                <span>Update</span>
+              </Button>
+            </Link>
 
-        <Alert
-          title="Are you sure you want to delete the container??"
-          description="The container? will be deleted, and removed from all sensors that are currently using it."
-          trigger={
-            <Button
-              variant="subtle"
-              className="flex items-center justify-center gap-x-2"
-            >
-              <TrashIcon className="w-4" />
-              <span>Delete</span>
-            </Button>
-          }
-          onDelete={onDelete}
-        />
-      </div>
+            <Alert
+              title="Are you sure you want to delete the container??"
+              description="The container? will be deleted, and removed from all sensors that are currently using it."
+              trigger={
+                <Button
+                  variant="subtle"
+                  className="flex items-center justify-center gap-x-2"
+                >
+                  <TrashIcon className="w-4" />
+                  <span>Delete</span>
+                </Button>
+              }
+              onDelete={onDelete}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -106,7 +106,7 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
       <ul className="list-disc ml-8">
         {sensors.map((sensor) => (
           <li key={sensor.id}>
-            <Link href={`../sensors/${sensor.id}`}>{sensor.name}</Link>
+            <Link className="hover:underline" href={`../sensors/${sensor.id}`}>{sensor.name}</Link>
           </li>
         ))}
       </ul>

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -28,6 +28,7 @@ type ContainerPageProps = InferGetServerSidePropsType<
 const ContainerPage = ({ id }: ContainerPageProps) => {
 
   const router = useRouter();
+  
   const {
     data: container,
     isLoading: containerIsLoading,

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/ui/AlertDialog"
 import { Textarea } from "@/ui/Textarea";
 import H4 from "@/ui/typography/H4";
+import LoadingSpinner from "@/ui/LoadingSpinner";
 
 type ContainerPageProps = InferGetServerSidePropsType<
   typeof getServerSideProps
@@ -41,7 +42,6 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
   } = trpc.container.getSensorsByContainerId.useQuery({
     containerId: id,
   });
-
   const {
     mutate: deleteContainer,
     isLoading: deleteContainerIsLoading,
@@ -50,35 +50,13 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
 
 
   if (containerIsLoading || sensorsIsLoading || deleteContainerIsLoading) {
-    return <div>Loading...</div>;
+    return <LoadingSpinner />;
   }
 
   if (containerError || sensorsError || deleteContainerError) {
     return <div>Error</div>;
   }
-
-  const handleDelete = async () => {
-    try {
-      await deleteContainer({ containerId: id });
-      toast({
-        title: "Success!",
-        description: "Container was deletedy. You will now be redirected to the dashboard",
-        severity: "success",
-      });
-      router.push({
-        pathname: "/",
-      });
-    } catch (error) {
-      // Handle the error, for example:
-      console.error("Failed to delete container:", error);
-      toast({
-        title: "Error!",
-        description: "There was an error while deleting the container",
-        severity: "error",
-      });
-    }
-  };  
-
+  
   if (!container) {
     return     <div className="flex flex-col items-center justify-center gap-y-4">
     <H1>Oh no!</H1>
@@ -90,6 +68,26 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
     </Link>
   </div>;
   }
+
+  const handleDelete = async () => {
+    try {
+      await deleteContainer({ containerId: id });
+      toast({
+        title: "Success!",
+        description: "Container was deleted. You will now be redirected to the dashboard",
+        severity: "success",
+      });
+      router.push({
+        pathname: "/",
+      });
+    } catch (error) {
+      toast({
+        title: "Error!",
+        description: "There was an error while deleting the container",
+        severity: "error",
+      });
+    }
+  };  
 
   //TODO change textarea with card from tremor
   return (
@@ -108,7 +106,7 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
       <ul className="list-disc ml-8">
         {sensors.map((sensor) => (
           <li key={sensor.id}>
-            {sensor.name} 
+            <Link href={`../sensors/${sensor.id}`}>{sensor.name}</Link>
           </li>
         ))}
       </ul>

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -9,7 +9,7 @@ import { useRouter } from "next/router";
 import { Textarea } from "@/ui/Textarea";
 import H4 from "@/ui/typography/H4";
 import LoadingSpinner from "@/ui/LoadingSpinner";
-import DeleteContainerAlert from "@/ui/containers/DeleteContainerAlert";
+import Alert from "@/ui/Alert";
 import { PencilIcon, TrashIcon } from "@heroicons/react/24/outline";
 
 type ContainerPageProps = InferGetServerSidePropsType<
@@ -100,10 +100,7 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
         <ul className="ml-8 list-disc">
           {sensors.map((sensor) => (
             <li key={sensor.id}>
-              <Link
-                className="hover:underline"
-                href={`/dashboard/sensors/${sensor.id}`}
-              >
+              <Link className="hover:underline" href={`/sensors/${sensor.id}`}>
                 {sensor.name}
               </Link>
             </li>
@@ -111,7 +108,7 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
         </ul>
       </div>
       <div className="items-left justify-left my-4 flex flex-row gap-x-4">
-        <Link href={`/dashboard/containers/${id}/update`}>
+        <Link href={`/containers/${id}/update`}>
           <Button
             variant="subtle"
             className="flex items-center justify-center gap-x-2"
@@ -121,7 +118,9 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
           </Button>
         </Link>
 
-        <DeleteContainerAlert
+        <Alert
+          title="Are you sure you want to delete the container?"
+          description="The container will be deleted, and removed from all sensors that are currently using it."
           trigger={
             <Button
               variant="subtle"

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -22,9 +22,31 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
     containerId: id,
   });
 
+  if (containerIsLoading || sensorsIsLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (containerError || sensorsError) {
+    return <div>Error</div>;
+  }
+
+  if (!container) {
+    return <div>Container not found</div>;
+  }
+
   return (
     <div>
-      <H1>Container</H1>
+      <H1>Container {container.id}</H1>
+      <p>Description: {container.description}</p>
+      <p>Name: {container.name}</p>
+      <p>Sensors:</p>
+      <ul>
+        {sensors.map((sensor) => (
+          <li key={sensor.id}>
+            {sensor.name} 
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/apps/web/src/pages/containers/[id]/index.tsx
+++ b/apps/web/src/pages/containers/[id]/index.tsx
@@ -1,15 +1,30 @@
+import { toast } from "@/hooks/toast/useToast";
 import { Button } from "@/ui/Button";
 import H1 from "@/ui/typography/H1";
 import Subtle from "@/ui/typography/Subtle";
 import { trpc } from "@/utils/trpc";
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/ui/AlertDialog"
 
 type ContainerPageProps = InferGetServerSidePropsType<
   typeof getServerSideProps
 >;
 
 const ContainerPage = ({ id }: ContainerPageProps) => {
+
+  const router = useRouter();
   const {
     data: container,
     isLoading: containerIsLoading,
@@ -25,13 +40,42 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
     containerId: id,
   });
 
-  if (containerIsLoading || sensorsIsLoading) {
+  const {
+    mutate: deleteContainer,
+    isLoading: deleteContainerIsLoading,
+    error: deleteContainerError,
+  } = trpc.container.delete.useMutation();
+
+
+  if (containerIsLoading || sensorsIsLoading || deleteContainerIsLoading) {
     return <div>Loading...</div>;
   }
 
-  if (containerError || sensorsError) {
+  if (containerError || sensorsError || deleteContainerError) {
     return <div>Error</div>;
   }
+
+  const handleDelete = async () => {
+    try {
+      await deleteContainer({ containerId: id });
+      toast({
+        title: "Success!",
+        description: "Container was deletedy. You will now be redirected to the dashboard",
+        severity: "success",
+      });
+      router.push({
+        pathname: "/",
+      });
+    } catch (error) {
+      // Handle the error, for example:
+      console.error("Failed to delete container:", error);
+      toast({
+        title: "Error!",
+        description: "There was an error while deleting the container",
+        severity: "error",
+      });
+    }
+  };  
 
   if (!container) {
     return     <div className="flex flex-col items-center justify-center gap-y-4">
@@ -40,7 +84,7 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
       It looks like the container you&apos;re looking for doesn&apos;t exist.
     </Subtle>
     <Link href="/">
-      <Button variant="subtle">Take me home</Button>
+      <Button variant="subtle">Return home</Button>
     </Link>
   </div>;
   }
@@ -60,6 +104,23 @@ const ContainerPage = ({ id }: ContainerPageProps) => {
           </li>
         ))}
       </ul>
+      <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline">Delete Container</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Once executed, this action cannot be reversed. It will permanently delete the container and remove it from all sensors that are currently using it.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleDelete}>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
     </div>
   );
 };

--- a/apps/web/src/pages/sensors/[id]/index.tsx
+++ b/apps/web/src/pages/sensors/[id]/index.tsx
@@ -69,6 +69,8 @@ const SensorPage = ({ id }: SensorPageProps) => {
     }
   };  
 
+  const container = containerData?.find((c) => c.id === sensor.sensor.containerId);
+
   return (
     <div>
       <H1>{sensor.sensor.name}</H1>
@@ -76,13 +78,12 @@ const SensorPage = ({ id }: SensorPageProps) => {
       <H4>Location</H4>
       <p>{sensor.sensor.location}</p>
       <H4>Container</H4>
-      {sensor.sensor.containerId ? (
-      <a href={`../containers/${sensor.sensor.containerId}`}>
-        {containerData?.find((c) => c.id === sensor.sensor.containerId)?.name || "No container"}
-      </a>
+      {container ? (
+        <><Link className="hover:underline" href={`../containers/${sensor.sensor.containerId}`}>{container.name}</Link>
+        </>
       ) : (
       <span>
-        {containerData?.find((c) => c.id === sensor.sensor.containerId)?.name || "No container"}
+        No container
       </span>
       )}
       <H4>Description</H4>

--- a/apps/web/src/pages/sensors/[id]/index.tsx
+++ b/apps/web/src/pages/sensors/[id]/index.tsx
@@ -23,7 +23,9 @@ import LoadingSpinner from "@/ui/LoadingSpinner";
 type SensorPageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
 
 const SensorPage = ({ id }: SensorPageProps) => {
+  
   const router = useRouter();
+
   const {
     data: sensor,
     isLoading: sensorIsLoading,
@@ -40,7 +42,7 @@ const SensorPage = ({ id }: SensorPageProps) => {
     error: deleteSensorError,
   } = trpc.sensor.delete.useMutation();
   
-  if (sensorIsLoading || deleteSensorIsLoading) {
+  if (sensorIsLoading || deleteSensorIsLoading || containerIsLoading) {
     return <LoadingSpinner />;
   }
 

--- a/apps/web/src/pages/sensors/[id]/index.tsx
+++ b/apps/web/src/pages/sensors/[id]/index.tsx
@@ -22,26 +22,17 @@ const SensorPage = ({ id }: SensorPageProps) => {
     error: sensorError,
   } = trpc.sensor.get.useQuery({ id });
   const {
-    data: containerData,
-    isLoading: containerIsLoading,
-    error: containerError,
-  } = trpc.container.getAll.useQuery();
-  const {
     mutate: deleteSensor,
     isLoading: deleteSensorIsLoading,
     error: deleteSensorError,
   } = trpc.sensor.delete.useMutation();
 
-  if (sensorIsLoading || deleteSensorIsLoading || containerIsLoading) {
+  if (sensorIsLoading || deleteSensorIsLoading) {
     return <LoadingSpinner />;
   }
 
   if (sensorError) {
     return <div>sensorError {sensorError.message}</div>;
-  }
-
-  if (containerError) {
-    return <div>containerError {containerError.message}</div>;
   }
 
   if (deleteSensorError) {
@@ -69,10 +60,6 @@ const SensorPage = ({ id }: SensorPageProps) => {
     }
   };
 
-  const container = containerData?.find(
-    (c) => c.id === sensor.sensor.containerId,
-  );
-
   return (
     <div>
       <H1>{sensor.sensor.name}</H1>
@@ -80,13 +67,13 @@ const SensorPage = ({ id }: SensorPageProps) => {
         <H4>Location</H4>
         <p>{sensor.sensor.location}</p>
         <H4>Container</H4>
-        {container ? (
+        {sensor.container ? (
           <>
             <Link
               className="hover:underline"
               href={`/containers/${sensor.sensor.containerId}`}
             >
-              {container.name}
+              {sensor.container.name}
             </Link>
           </>
         ) : (

--- a/apps/web/src/pages/sensors/[id]/index.tsx
+++ b/apps/web/src/pages/sensors/[id]/index.tsx
@@ -1,113 +1,76 @@
-import { toast } from "@/hooks/toast/useToast";
 import { Button } from "@/ui/Button";
 import H1 from "@/ui/typography/H1";
-import { trpc } from "@/utils/trpc";
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { Textarea } from "@/ui/Textarea";
 import H4 from "@/ui/typography/H4";
-import LoadingSpinner from "@/ui/LoadingSpinner";
 import { PencilIcon, TrashIcon } from "@heroicons/react/24/outline";
 import Alert from "@/ui/Alert";
+import useGetSensor from "@/hooks/queries/useGetSensor";
+import LoadingSpinner from "@/ui/LoadingSpinner";
 
 type SensorPageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
 
 const SensorPage = ({ id }: SensorPageProps) => {
-  const router = useRouter();
-
-  const {
-    data: sensor,
-    isLoading: sensorIsLoading,
-    error: sensorError,
-  } = trpc.sensor.get.useQuery({ id });
-  const {
-    mutate: deleteSensor,
-    isLoading: deleteSensorIsLoading,
-    error: deleteSensorError,
-  } = trpc.sensor.delete.useMutation();
-
-  if (sensorIsLoading || deleteSensorIsLoading) {
-    return <LoadingSpinner />;
-  }
-
-  if (sensorError) {
-    return <div>sensorError {sensorError.message}</div>;
-  }
-
-  if (deleteSensorError) {
-    return <div>deleteSensorError {deleteSensorError.message}</div>;
-  }
+  const { data, isLoading, deleteSensorMutation } = useGetSensor({ id });
 
   const onDelete = async () => {
-    try {
-      await deleteSensor({ sensorId: id });
-      toast({
-        title: "Success!",
-        description:
-          "Sensor was deleted. You will now be redirected to the dashboard",
-        severity: "success",
-      });
-      router.push({
-        pathname: "/",
-      });
-    } catch (error) {
-      toast({
-        title: "Error!",
-        description: "There was an error while deleting the sensor",
-        severity: "error",
-      });
-    }
+    await deleteSensorMutation({ sensorId: id });
   };
 
   return (
     <div>
-      <H1>{sensor.sensor.name}</H1>
-      <div className="items-left justify-left my-4 flex flex-col">
-        <H4>Location</H4>
-        <p>{sensor.sensor.location}</p>
-        <H4>Container</H4>
-        {sensor.container ? (
-          <>
-            <Link
-              className="hover:underline"
-              href={`/containers/${sensor.sensor.containerId}`}
-            >
-              {sensor.container.name}
+      {isLoading && <LoadingSpinner />}
+      {!isLoading && data && (
+        <div className="flex flex-col items-center justify-center">
+          <H1>{data?.sensor.name}</H1>
+          <div className="items-left justify-left my-4 flex flex-col">
+            <H4>Location</H4>
+            <p>{data?.sensor.location}</p>
+            <H4>Container</H4>
+            {data?.container ? (
+              <>
+                <Link
+                  className="hover:underline"
+                  href={`/containers/${data.sensor.containerId}`}
+                >
+                  {data.container.name}
+                </Link>
+              </>
+            ) : (
+              <span>No container</span>
+            )}
+            <H4>Description</H4>
+            <Textarea value={data?.sensor.description} disabled />
+          </div>
+          <div className="items-left justify-left my-4 flex flex-row gap-x-4">
+            <Link href={`/sensors/${id}/update`}>
+              <Button
+                variant="subtle"
+                className="flex items-center justify-center gap-x-2"
+              >
+                <PencilIcon className="w-4" />
+                <span>Update</span>
+              </Button>
             </Link>
-          </>
-        ) : (
-          <span>No container</span>
-        )}
-        <H4>Description</H4>
-        <Textarea value={sensor.sensor.description} disabled />
-      </div>
-      <div className="items-left justify-left my-4 flex flex-row gap-x-4">
-        <Link href={`/sensors/${id}/update`}>
-          <Button
-            variant="subtle"
-            className="flex items-center justify-center gap-x-2"
-          >
-            <PencilIcon className="w-4" />
-            <span>Update</span>
-          </Button>
-        </Link>
 
-        <Alert
-          title="Are you sure you want to delete the sensor?"
-          description="The sensor will be permanently deleted."
-          trigger={
-            <Button
-              variant="subtle"
-              className="flex items-center justify-center gap-x-2"
-            >
-              <TrashIcon className="w-4" />
-              <span>Delete</span>
-            </Button>
-          }
-          onDelete={onDelete}
-        />
-      </div>
+            <Alert
+              title="Are you sure you want to delete the sensor?"
+              description="The sensor will be permanently deleted."
+              trigger={
+                <Button
+                  variant="subtle"
+                  className="flex items-center justify-center gap-x-2"
+                >
+                  <TrashIcon className="w-4" />
+                  <span>Delete</span>
+                </Button>
+              }
+              onDelete={onDelete}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/web/src/pages/sensors/[id]/index.tsx
+++ b/apps/web/src/pages/sensors/[id]/index.tsx
@@ -1,7 +1,6 @@
 import { toast } from "@/hooks/toast/useToast";
 import { Button } from "@/ui/Button";
 import H1 from "@/ui/typography/H1";
-import Subtle from "@/ui/typography/Subtle";
 import { trpc } from "@/utils/trpc";
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
@@ -45,8 +44,8 @@ const SensorPage = ({ id }: SensorPageProps) => {
     return <LoadingSpinner />;
   }
 
-  if (sensorError) {
-    return <div>Error du {sensorError.message}</div>;
+  if (sensorError || containerError || deleteSensorError) {
+    return <div>Error</div>;
   }
 
   const handleDelete = async () => {

--- a/apps/web/src/pages/sensors/[id]/index.tsx
+++ b/apps/web/src/pages/sensors/[id]/index.tsx
@@ -5,25 +5,15 @@ import { trpc } from "@/utils/trpc";
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/ui/AlertDialog"
 import { Textarea } from "@/ui/Textarea";
 import H4 from "@/ui/typography/H4";
 import LoadingSpinner from "@/ui/LoadingSpinner";
+import { PencilIcon, TrashIcon } from "@heroicons/react/24/outline";
+import Alert from "@/ui/Alert";
 
 type SensorPageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
 
 const SensorPage = ({ id }: SensorPageProps) => {
-  
   const router = useRouter();
 
   const {
@@ -41,7 +31,7 @@ const SensorPage = ({ id }: SensorPageProps) => {
     isLoading: deleteSensorIsLoading,
     error: deleteSensorError,
   } = trpc.sensor.delete.useMutation();
-  
+
   if (sensorIsLoading || deleteSensorIsLoading || containerIsLoading) {
     return <LoadingSpinner />;
   }
@@ -58,12 +48,13 @@ const SensorPage = ({ id }: SensorPageProps) => {
     return <div>deleteSensorError {deleteSensorError.message}</div>;
   }
 
-  const handleDelete = async () => {
+  const onDelete = async () => {
     try {
       await deleteSensor({ sensorId: id });
       toast({
         title: "Success!",
-        description: "Sensor was deleted. You will now be redirected to the dashboard",
+        description:
+          "Sensor was deleted. You will now be redirected to the dashboard",
         severity: "success",
       });
       router.push({
@@ -76,50 +67,60 @@ const SensorPage = ({ id }: SensorPageProps) => {
         severity: "error",
       });
     }
-  };  
+  };
 
-  const container = containerData?.find((c) => c.id === sensor.sensor.containerId);
+  const container = containerData?.find(
+    (c) => c.id === sensor.sensor.containerId,
+  );
 
   return (
     <div>
       <H1>{sensor.sensor.name}</H1>
-      <div className="my-4 flex flex-col items-left justify-left">
-      <H4>Location</H4>
-      <p>{sensor.sensor.location}</p>
-      <H4>Container</H4>
-      {container ? (
-        <><Link className="hover:underline" href={`../containers/${sensor.sensor.containerId}`}>{container.name}</Link>
-        </>
-      ) : (
-      <span>
-        No container
-      </span>
-      )}
-      <H4>Description</H4>
-      <Textarea value={sensor.sensor.description} disabled />
-    </div>
-    <div className="my-4 flex flex-row items-left justify-left gap-x-4">
-      <Link href={`${id}/update`}>
-      <Button variant="subtle">Update</Button>
-    </Link>
-      <AlertDialog>
-      <AlertDialogTrigger asChild>
-        <Button variant="subtle">Delete</Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-          <AlertDialogDescription>
-            Once executed, this action cannot be reversed. It will permanently delete this sensor.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={handleDelete}>Continue</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-    </div>
+      <div className="items-left justify-left my-4 flex flex-col">
+        <H4>Location</H4>
+        <p>{sensor.sensor.location}</p>
+        <H4>Container</H4>
+        {container ? (
+          <>
+            <Link
+              className="hover:underline"
+              href={`/containers/${sensor.sensor.containerId}`}
+            >
+              {container.name}
+            </Link>
+          </>
+        ) : (
+          <span>No container</span>
+        )}
+        <H4>Description</H4>
+        <Textarea value={sensor.sensor.description} disabled />
+      </div>
+      <div className="items-left justify-left my-4 flex flex-row gap-x-4">
+        <Link href={`/sensors/${id}/update`}>
+          <Button
+            variant="subtle"
+            className="flex items-center justify-center gap-x-2"
+          >
+            <PencilIcon className="w-4" />
+            <span>Update</span>
+          </Button>
+        </Link>
+
+        <Alert
+          title="Are you sure you want to delete the sensor?"
+          description="The sensor will be permanently deleted."
+          trigger={
+            <Button
+              variant="subtle"
+              className="flex items-center justify-center gap-x-2"
+            >
+              <TrashIcon className="w-4" />
+              <span>Delete</span>
+            </Button>
+          }
+          onDelete={onDelete}
+        />
+      </div>
     </div>
   );
 };
@@ -128,6 +129,7 @@ export const getServerSideProps = async (
   context: GetServerSidePropsContext<{ id: string }>,
 ) => {
   const id = context.params?.id;
+
   if (!id) {
     return {
       redirect: {

--- a/apps/web/src/pages/sensors/[id]/index.tsx
+++ b/apps/web/src/pages/sensors/[id]/index.tsx
@@ -44,8 +44,16 @@ const SensorPage = ({ id }: SensorPageProps) => {
     return <LoadingSpinner />;
   }
 
-  if (sensorError || containerError || deleteSensorError) {
-    return <div>Error</div>;
+  if (sensorError) {
+    return <div>sensorError {sensorError.message}</div>;
+  }
+
+  if (containerError) {
+    return <div>containerError {containerError.message}</div>;
+  }
+
+  if (deleteSensorError) {
+    return <div>deleteSensorError {deleteSensorError.message}</div>;
   }
 
   const handleDelete = async () => {

--- a/apps/web/src/ui/Alert.tsx
+++ b/apps/web/src/ui/Alert.tsx
@@ -9,27 +9,25 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "../AlertDialog";
-import { red } from "tailwindcss/colors";
+} from "./AlertDialog";
 
-type DeleteContainerAlert = {
+type Alert = {
+  title: string;
+  description?: string;
   trigger: ReactNode;
   onDelete: () => void;
 };
 
-const DeleteContainerAlert = ({ trigger, onDelete }: DeleteContainerAlert) => {
+const Alert = ({ title, description, trigger, onDelete }: Alert) => {
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
 
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>
-            Are you sure you want to delete the container?
-          </AlertDialogTitle>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>
-            The container will be deleted, and removed from all sensors that are
-            currently using it.
+            {description || "This action cannot be undone."}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -46,4 +44,4 @@ const DeleteContainerAlert = ({ trigger, onDelete }: DeleteContainerAlert) => {
   );
 };
 
-export default DeleteContainerAlert;
+export default Alert;

--- a/apps/web/src/ui/AlertDialog.tsx
+++ b/apps/web/src/ui/AlertDialog.tsx
@@ -1,0 +1,153 @@
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import { cn } from "../utils/tailwind";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = ({
+  className,
+  children,
+  ...props
+}: AlertDialogPrimitive.AlertDialogPortalProps) => (
+  <AlertDialogPrimitive.Portal className={cn(className)} {...props}>
+    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
+      {children}
+    </div>
+  </AlertDialogPrimitive.Portal>
+);
+AlertDialogPortal.displayName = AlertDialogPrimitive.Portal.displayName;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, children, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity animate-in fade-in",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed z-50 grid w-full max-w-lg scale-100 gap-4 bg-white p-6 opacity-100 animate-in fade-in-90 slide-in-from-bottom-10 sm:rounded-lg sm:zoom-in-90 sm:slide-in-from-bottom-0 md:w-full",
+        "dark:bg-slate-900",
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold text-slate-900",
+      "dark:text-slate-50",
+      className,
+    )}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-slate-500", "dark:text-slate-400", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(
+      "dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200 dark:focus:ring-slate-400 dark:focus:ring-offset-slate-900 inline-flex h-10 items-center justify-center rounded-md bg-slate-900 py-2 px-4 text-sm font-semibold text-white transition-colors hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      "dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-700 dark:focus:ring-slate-400 dark:focus:ring-offset-slate-900 mt-2 inline-flex h-10 items-center justify-center rounded-md border border-slate-200 bg-transparent py-2 px-4 text-sm font-semibold text-slate-900 transition-colors hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:mt-0",
+      className,
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/apps/web/src/ui/LoadingSpinner.tsx
+++ b/apps/web/src/ui/LoadingSpinner.tsx
@@ -17,7 +17,7 @@ const LoadingSpinner = ({ className }: LoadingSpinnerProps) => {
         cy="12"
         r="10"
         stroke="currentColor"
-        stroke-width="4"
+        strokeWidth="4"
       ></circle>
       <path
         className="opacity-75"

--- a/apps/web/src/ui/containers/DeleteContainerAlert.tsx
+++ b/apps/web/src/ui/containers/DeleteContainerAlert.tsx
@@ -1,0 +1,49 @@
+import { ReactNode } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "../AlertDialog";
+import { red } from "tailwindcss/colors";
+
+type DeleteContainerAlert = {
+  trigger: ReactNode;
+  onDelete: () => void;
+};
+
+const DeleteContainerAlert = ({ trigger, onDelete }: DeleteContainerAlert) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Are you sure you want to delete the container?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            The container will be deleted, and removed from all sensors that are
+            currently using it.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onDelete}
+            className="border border-red-600 bg-red-500 hover:bg-red-600"
+          >
+            Confirm
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default DeleteContainerAlert;

--- a/apps/web/src/ui/map/AllSensorsMap.tsx
+++ b/apps/web/src/ui/map/AllSensorsMap.tsx
@@ -20,13 +20,6 @@ const AllSensorsMap = () => {
           )}
         </div>
       )}
-      <div className="py-8">
-        {!isLoading && !error && (
-          <div className="flex items-center justify-center">
-            <Subtle>All sensors loaded successfully.</Subtle>
-          </div>
-        )}
-      </div>
     </div>
   );
 };

--- a/apps/web/src/ui/map/SensorMarkerPopover.tsx
+++ b/apps/web/src/ui/map/SensorMarkerPopover.tsx
@@ -2,21 +2,29 @@ import { PopoverProps } from "@radix-ui/react-popover";
 import P from "../typography/P";
 import Subtle from "../typography/Subtle";
 import { Popover } from "../Popover";
+import Link from "next/link";
 
 type SensorMarkerPopoverProps = PopoverProps & {
   title: string;
   content: string;
+  link: string;
+  linkContent: string;
 };
 
 const SensorMarkerPopover = ({
   title,
   content,
+  link,
+  linkContent,
   ...props
 }: SensorMarkerPopoverProps) => {
   return (
     <Popover {...props}>
       <P className="font-bold">{title}</P>
       <Subtle>{content}</Subtle>
+      <Link href={link}>
+        <Subtle className="hover:underline">{linkContent}</Subtle>
+        </Link>
     </Popover>
   );
 };

--- a/apps/web/src/ui/map/SensorMarkerPopover.tsx
+++ b/apps/web/src/ui/map/SensorMarkerPopover.tsx
@@ -3,19 +3,20 @@ import P from "../typography/P";
 import Subtle from "../typography/Subtle";
 import { Popover } from "../Popover";
 import Link from "next/link";
+import { Button } from "../Button";
 
 type SensorMarkerPopoverProps = PopoverProps & {
   title: string;
   content: string;
   link: string;
-  linkContent: string;
+  linkLabel: string;
 };
 
 const SensorMarkerPopover = ({
   title,
   content,
   link,
-  linkContent,
+  linkLabel,
   ...props
 }: SensorMarkerPopoverProps) => {
   return (
@@ -23,8 +24,10 @@ const SensorMarkerPopover = ({
       <P className="font-bold">{title}</P>
       <Subtle>{content}</Subtle>
       <Link href={link}>
-        <Subtle className="hover:underline">{linkContent}</Subtle>
-        </Link>
+        <Button size="sm" variant="subtle">
+          {linkLabel}
+        </Button>
+      </Link>
     </Popover>
   );
 };

--- a/packages/api/src/router/container.ts
+++ b/packages/api/src/router/container.ts
@@ -56,7 +56,7 @@ export const containerRouter = router({
   get: protectedProcedure
     .input(ContainerIdSchema)
     .query(async ({ ctx, input }) => {
-      const { containerId: containerTypeId } = input;
+      const { containerId } = input;
 
       const isMemberOfOrganization = await userIsMemberOfOrganization(
         ctx.auth.user?.id,
@@ -69,11 +69,20 @@ export const containerRouter = router({
         });
       }
 
-      return ctx.prisma.container.findUnique({
+      const container = await ctx.prisma.container.findUnique({
         where: {
-          id: containerTypeId,
+          id: containerId,
         },
       });
+
+      if (!container) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Container not found",
+        });
+      }
+
+      return container;
     }),
 
   getAll: protectedProcedure.query(async ({ ctx }) => {

--- a/packages/api/src/router/sensor.ts
+++ b/packages/api/src/router/sensor.ts
@@ -167,15 +167,8 @@ export const sensorRouter = router({
         },
       });
 
-      const timeseries = Sensor.selectAll()
-        .where("sensor_id", "=", id)
-        .orderBy("time", "desc")
-        .limit(1)
-        .execute();
-
       return {
         sensor,
-        timeseries,
         container,
       };
     }),

--- a/packages/api/src/router/sensor.ts
+++ b/packages/api/src/router/sensor.ts
@@ -95,19 +95,26 @@ export const sensorRouter = router({
         })
         .then((org) => org);
 
-      return ctx.prisma.sensor.create({
-        data: {
-          id: sensorId,
-          collectionId,
-          latitude,
-          longitude,
-          name,
-          description,
-          location: location || "",
-          containerId,
-          organizationId: ctx.auth.organizationId,
-        },
-      });
+      return ctx.prisma.sensor
+        .create({
+          data: {
+            id: sensorId,
+            collectionId,
+            latitude,
+            longitude,
+            name,
+            description,
+            location: location || "",
+            containerId,
+            organizationId: ctx.auth.organizationId,
+          },
+        })
+        .catch(() => {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "It seems like this sensor already exists.",
+          });
+        });
     }),
 
   get: protectedProcedure

--- a/packages/api/src/router/sensor.ts
+++ b/packages/api/src/router/sensor.ts
@@ -163,7 +163,7 @@ export const sensorRouter = router({
 
       const container = await ctx.prisma.container.findUnique({
         where: {
-          id: sensor.containerId || undefined,
+          id: sensor.containerId || undefined || "",
         },
       });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       '@mapbox/mapbox-gl-geocoder':
         specifier: ^5.0.1
         version: 5.0.1(mapbox-gl@2.13.0)
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.0.3
+        version: 1.0.3(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-dialog':
         specifier: ^1.0.3
         version: 1.0.3(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0)
@@ -87,7 +90,7 @@ importers:
         version: 4.24.10(react-dom@18.2.0)(react@18.2.0)
       '@tremor/react':
         specifier: ^2.0.0
-        version: 2.0.0(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.0.0(react-dom@18.2.0)(react@18.2.0)
       '@trpc/client':
         specifier: ^10.13.0
         version: 10.13.0(@trpc/server@10.13.0)
@@ -1392,6 +1395,25 @@ packages:
       '@babel/runtime': 7.21.0
     dev: false
 
+  /@radix-ui/react-alert-dialog@1.0.3(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-QXFy7+bhGi0u+paF2QbJeSCHZs4gLMJIPm6sajUamyW0fro6g1CaSGc5zmc4QmK2NlSGUrq8m+UsUqJYtzvXow==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@radix-ui/primitive': 1.0.0
+      '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
+      '@radix-ui/react-context': 1.0.0(react@18.2.0)
+      '@radix-ui/react-dialog': 1.0.3(@types/react@18.0.25)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.2(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.1(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
   /@radix-ui/react-arrow@1.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-fqYwhhI9IarZ0ll2cUSfKuXHlJK0qE4AfnRrPBbRwEH/4mGQn04/QFGomLi8TXWIdv9WJk//KgGm+aDxVIr1wA==}
     peerDependencies:
@@ -2293,7 +2315,7 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  /@tremor/react@2.0.0(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0):
+  /@tremor/react@2.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-F4UtSpBm6FZurWnv5A8lvr8NM3j6MCGLVz8LbfaQ9M36V53KTg0dNXuyjQf3Bhn+pNAK1nTi87JFIinDuZTy1Q==}
     peerDependencies:
       react: ^18.0.0
@@ -2302,7 +2324,7 @@ packages:
       date-fns: 2.29.3
       react: 18.2.0
       react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
-      recharts: 2.5.0(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
+      recharts: 2.5.0(react-dom@18.2.0)(react@18.2.0)
       tailwind-merge: 1.10.0
     transitivePeerDependencies:
       - prop-types
@@ -6756,7 +6778,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /react-smooth@2.0.2(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0):
+  /react-smooth@2.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-pgqSp1q8rAGtF1bXQE0m3CHGLNfZZh5oA5o1tsPLXRHnKtkujMIJ8Ws5nO1mTySZf1c4vgwlEk+pHi3Ln6eYLw==}
     peerDependencies:
       prop-types: ^15.6.0
@@ -6764,7 +6786,6 @@ packages:
       react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
       fast-equals: 4.0.3
-      prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-transition-group: 2.9.0(react-dom@18.2.0)(react@18.2.0)
@@ -6897,7 +6918,7 @@ packages:
       decimal.js-light: 2.5.1
     dev: false
 
-  /recharts@2.5.0(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0):
+  /recharts@2.5.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-0EQYz3iA18r1Uq8VqGZ4dABW52AKBnio37kJgnztIqprELJXpOEsa0SzkqU1vjAhpCXCv52Dx1hiL9119xsqsQ==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -6908,12 +6929,11 @@ packages:
       classnames: 2.3.2
       eventemitter3: 4.0.7
       lodash: 4.17.21
-      prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-is: 16.13.1
       react-resize-detector: 8.0.4(react-dom@18.2.0)(react@18.2.0)
-      react-smooth: 2.0.2(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
+      react-smooth: 2.0.2(react-dom@18.2.0)(react@18.2.0)
       recharts-scale: 0.4.5
       reduce-css-calc: 2.1.8
       victory-vendor: 36.6.8


### PR DESCRIPTION
Closes: #51, #9, #24

## Checklist

- [ ] I have written tests
- [ ] I have provided documentation

## Changelog
Detailed view about one container 
- Type of container
- Size of container
- Note
- Button to delete container with modal
- Button to update metadata about container (fields in the db)
- List over sensors that belong to the container

Detailed view about one sensor
-  Type of container with link to page for that container
- Location
- Note
- Button to delete sensor with modal
- Button to update metadata about sensor (for instance type of container, note, etc...)

## How to test
- Make sure you have a sensor on the map on the dashboard and a container connected to this sensor
- Click on the see more button on the popup to see the sensorview
- Click on the container name to see the containerview
- If you delete the container this field will also be updated in the sensorview
- If a container has no sensors then the list will be empty (maybe a check should be added here)

Notes:
- Styling is not done
- Map in both views will be implemented in a new issue