### PR TITLE
fix: Take `sensors` as parameter in sensors map

### DIFF
--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -3,21 +3,28 @@ import type {
   InferGetServerSidePropsType,
 } from "next";
 import { getAuth } from "@clerk/nextjs/server";
-import SetSensorPositionMap from "@/ui/map/SetSensorPositionMap";
 import { trpc } from "@/utils/trpc";
 import LoadingSpinner from "@/ui/LoadingSpinner";
 import { useEffect } from "react";
 import AllSensorsMap from "@/ui/map/AllSensorsMap";
+import useErrorToast from "@/hooks/toast/useErrorToast";
 
 type IndexPageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
 
 const IndexPage = ({ userId }: IndexPageProps) => {
   const { mutateAsync, isLoading } = trpc.user.createIfNotExists.useMutation();
+  const {
+    data: sensors,
+    isLoading: sensorsIsLoading,
+    error,
+  } = trpc.sensor.getAll.useQuery();
 
   useEffect(() => {
     if (!userId) return;
     mutateAsync({ userId });
   }, [mutateAsync, userId]);
+
+  useErrorToast({ error });
 
   return (
     <div className="flex flex-col items-center justify-center gap-12 px-4 py-8">
@@ -32,7 +39,8 @@ const IndexPage = ({ userId }: IndexPageProps) => {
             Dashboard
           </h1>
 
-          <AllSensorsMap />
+          {sensorsIsLoading && !sensors && <LoadingSpinner />}
+          {!sensorsIsLoading && sensors && <AllSensorsMap sensors={sensors} />}
         </>
       )}
     </div>

--- a/apps/web/src/ui/map/AllSensorsMap.tsx
+++ b/apps/web/src/ui/map/AllSensorsMap.tsx
@@ -1,12 +1,13 @@
-import useErrorToast from "@/hooks/toast/useErrorToast";
 import useAllSensorsMap from "@/hooks/map/useAllSensorsMap";
 import LoadingSpinner from "../LoadingSpinner";
-import Subtle from "../typography/Subtle";
+import { Sensor } from "@acme/db";
 
-const AllSensorsMap = () => {
-  const { container, isLoading, error } = useAllSensorsMap();
+type AllSensorsMapProps = {
+  sensors: Sensor[];
+};
 
-  useErrorToast({ error });
+const AllSensorsMap = ({ sensors }: AllSensorsMapProps) => {
+  const { container, isLoading } = useAllSensorsMap({ sensors });
 
   return (
     <div>

--- a/apps/web/src/utils/mapbox.tsx
+++ b/apps/web/src/utils/mapbox.tsx
@@ -1,0 +1,23 @@
+import SensorMarkerPopover from "@/ui/map/SensorMarkerPopover";
+import { Sensor } from "@acme/db";
+import ReactDOM from "react-dom";
+
+type CreatePopupNodeProps = {
+  sensor: Sensor;
+};
+
+export const createPopupNode = ({ sensor }: CreatePopupNodeProps) => {
+  const popupNode = document.createElement("div");
+
+  ReactDOM.render(
+    <SensorMarkerPopover
+      title={sensor.name}
+      content={sensor.location}
+      link={`sensors/${sensor.id}`}
+      linkLabel="See more"
+    />,
+    popupNode,
+  );
+
+  return popupNode;
+};


### PR DESCRIPTION
Closes: #54 

## Changelog

- fix: Take `sensors` as parameter in sensors map

## How to test

- Dashboard shows organization's sensors
