### PR TITLE
fix: Update sensor page

### DIFF
--- a/apps/web/src/hooks/forms/useCreateSensorForm.ts
+++ b/apps/web/src/hooks/forms/useCreateSensorForm.ts
@@ -44,7 +44,9 @@ const useCreateSensorForm = ({
       });
     },
   });
-  const [containerId, setContainerId] = useState<string | undefined>(undefined);
+  const [containerId, setContainerId] = useState<string | null | undefined>(
+    undefined,
+  );
 
   useEffect(() => {
     if (!isLoading) return;

--- a/apps/web/src/hooks/forms/useUpdateSensorForm.ts
+++ b/apps/web/src/hooks/forms/useUpdateSensorForm.ts
@@ -58,18 +58,16 @@ const useUpdateSensorForm = ({
     handleSubmit,
     setValue,
     formState: { errors },
-    getValues,
   } = useZodForm({
     schema: UpdateSensorFormSchema,
     defaultValues: {
-      containerId: sensor?.containerId || undefined,
       name: sensor?.name,
+      description: sensor?.description,
+      containerId: sensor?.containerId || undefined,
       latitude: sensor?.latitude,
       longitude: sensor?.longitude,
     },
   });
-
-  console.log(getValues());
 
   const onSubmit = async (data: z.infer<typeof UpdateSensorFormSchema>) => {
     await mutateAsync({
@@ -78,11 +76,21 @@ const useUpdateSensorForm = ({
     });
   };
 
+  useEffect(() => {
+    if (!sensor) return;
+    setContainerId(sensor.containerId);
+  }, [sensor]);
+
   // Whenever the containerId changes in the dropdown menu, update the form value.
   useEffect(() => {
     if (!containerId) return;
     setValue("containerId", containerId);
   }, [containerId, setValue]);
+
+  useEffect(() => {
+    if (!sensor?.containerId) return;
+    setValue("containerId", sensor?.containerId);
+  }, [sensor?.containerId, setValue]);
 
   useEffect(() => {
     if (!latitude) return;

--- a/apps/web/src/hooks/forms/useUpdateSensorForm.ts
+++ b/apps/web/src/hooks/forms/useUpdateSensorForm.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { z } from "zod";
 import { useToast } from "../toast/useToast";
 import useZodForm from "../useZodForm";
+import { Sensor } from "@acme/db";
 
 /**
  * We use this schema to omit the `sensorId` from the form, because the `id` is passed in as a prop.
@@ -14,6 +15,7 @@ const UpdateSensorFormSchema = UpdateSensorSchema.omit({
 });
 
 type UpdateSensorFormProps = {
+  sensor?: Sensor;
   id: string;
   latitude?: number;
   longitude?: number;
@@ -25,6 +27,7 @@ type UpdateSensorFormProps = {
  * @returns all objects and handlers needed to update a sensor.
  */
 const useUpdateSensorForm = ({
+  sensor,
   id,
   latitude,
   longitude,
@@ -46,16 +49,27 @@ const useUpdateSensorForm = ({
       });
     },
   });
-  const [containerId, setContainerId] = useState<string | undefined>(undefined);
+  const [containerId, setContainerId] = useState<string | null | undefined>(
+    sensor?.containerId,
+  );
 
   const {
     register,
     handleSubmit,
     setValue,
     formState: { errors },
+    getValues,
   } = useZodForm({
     schema: UpdateSensorFormSchema,
+    defaultValues: {
+      containerId: sensor?.containerId || undefined,
+      name: sensor?.name,
+      latitude: sensor?.latitude,
+      longitude: sensor?.longitude,
+    },
   });
+
+  console.log(getValues());
 
   const onSubmit = async (data: z.infer<typeof UpdateSensorFormSchema>) => {
     await mutateAsync({

--- a/apps/web/src/hooks/map/useSetSensorPositionMap.tsx
+++ b/apps/web/src/hooks/map/useSetSensorPositionMap.tsx
@@ -48,19 +48,22 @@ const useSetSensorPositionMap = ({
       return;
     }
 
+    const lat = latitude || geoLocationLat;
+    const lng = longitude || geoLocationLong;
+
     map.current = MapboxMap({
       container: "map",
       style: "mapbox://styles/mapbox/dark-v11",
       center: {
-        lat: latitude || geoLocationLat,
-        lng: longitude || geoLocationLong,
+        lat,
+        lng,
       },
     });
 
     const marker = MapboxMarker({
       addTo: map.current,
-      latitude: latitude || geoLocationLat,
-      longitude: longitude || geoLocationLong,
+      latitude: lat,
+      longitude: lng,
     });
     setSensorMarker(marker);
   }, [longitude, latitude, geoLocationLat, geoLocationLong]);

--- a/apps/web/src/hooks/map/useSetSensorPositionMap.tsx
+++ b/apps/web/src/hooks/map/useSetSensorPositionMap.tsx
@@ -43,8 +43,8 @@ const useSetSensorPositionMap = ({
       return;
     }
 
-    // Don't initialize map if no geo coordinates are available
-    if (!geoLocationLat || !geoLocationLong) {
+    // Don't initialize map if no coordinates are available
+    if (!latitude || !longitude || !geoLocationLat || !geoLocationLong) {
       return;
     }
 

--- a/apps/web/src/hooks/map/useSetSensorPositionMap.tsx
+++ b/apps/web/src/hooks/map/useSetSensorPositionMap.tsx
@@ -3,14 +3,23 @@ import useGeoLocation from "../useGeolocation";
 import { mapbox, MapboxMap, MapboxMarker } from "@acme/mapbox";
 import { trpc } from "@/utils/trpc";
 
+type SetSensorPositionMapProps = {
+  latitude?: number;
+  longitude?: number;
+};
+
 /**
  * Handles initialization of the map from Mapbox, and updates the sensor marker's position on move.
  *
  * @returns the `ref` to the map container. This is used to render the map, for instance in a `div` element: `<div ref={container} />`.
  */
-const useSetSensorPositionMap = () => {
+const useSetSensorPositionMap = ({
+  latitude,
+  longitude,
+}: SetSensorPositionMapProps) => {
   const container = useRef(null);
-  const { latitude, longitude } = useGeoLocation();
+  const { latitude: geoLocationLat, longitude: geoLocationLong } =
+    useGeoLocation();
   const map = useRef<mapbox.Map | null>(null);
   const [sensorMarker, setSensorMarker] = useState<mapbox.Marker | null>(null);
   const {
@@ -34,7 +43,8 @@ const useSetSensorPositionMap = () => {
       return;
     }
 
-    if (!longitude || !latitude) {
+    // Don't initialize map if no geo coordinates are available
+    if (!geoLocationLat || !geoLocationLong) {
       return;
     }
 
@@ -42,18 +52,18 @@ const useSetSensorPositionMap = () => {
       container: "map",
       style: "mapbox://styles/mapbox/dark-v11",
       center: {
-        lat: latitude,
-        lng: longitude,
+        lat: latitude || geoLocationLat,
+        lng: longitude || geoLocationLong,
       },
     });
 
     const marker = MapboxMarker({
       addTo: map.current,
-      latitude,
-      longitude,
+      latitude: latitude || geoLocationLat,
+      longitude: longitude || geoLocationLong,
     });
     setSensorMarker(marker);
-  }, [longitude, latitude]);
+  }, [longitude, latitude, geoLocationLat, geoLocationLong]);
 
   // Update sensor marker's position when map is moved
   useEffect(() => {

--- a/apps/web/src/hooks/queries/useGetSensor.ts
+++ b/apps/web/src/hooks/queries/useGetSensor.ts
@@ -23,6 +23,11 @@ const useGetSensor = ({ id }: GetSensorProps) => {
           return;
         }
 
+        if (err.data?.code === "UNAUTHORIZED") {
+          router.push("/");
+          return;
+        }
+
         toast({
           title: "Error!",
           description: "There was an error while fetching the sensor",

--- a/apps/web/src/pages/sensors/[id]/update.tsx
+++ b/apps/web/src/pages/sensors/[id]/update.tsx
@@ -18,13 +18,22 @@ type UpdateSensorPageProps = InferGetServerSidePropsType<
 
 const UpdateSensorPage = ({ id }: UpdateSensorPageProps) => {
   const {
+    data,
+    isLoading: sensorIsLoading,
+    error: sensorError,
+  } = useGetSensor({ id });
+
+  const {
     container,
     data: location,
     isLoading: mapIsLoading,
     latitude,
     longitude,
     error: mapError,
-  } = useSetSensorPositionMap();
+  } = useSetSensorPositionMap({
+    latitude: data?.sensor.latitude,
+    longitude: data?.sensor.longitude,
+  });
 
   const {
     register,
@@ -34,15 +43,12 @@ const UpdateSensorPage = ({ id }: UpdateSensorPageProps) => {
     containerId,
     setContainerId,
   } = useUpdateSensorForm({
+    sensor: data?.sensor,
     id,
     latitude,
     longitude,
   });
-  const {
-    data,
-    isLoading: sensorIsLoading,
-    error: sensorError,
-  } = useGetSensor({ id });
+
   const {
     data: containerData,
     isLoading: containerIsLoading,
@@ -92,24 +98,6 @@ const UpdateSensorPage = ({ id }: UpdateSensorPageProps) => {
               setContainerId={setContainerId}
               data={containerData}
               isLoading={isLoading}
-            />
-
-            <FormInput
-              register={register}
-              id="latitude"
-              label="Latitude"
-              errorMessage={errors.latitude?.message}
-              valueAsNumber
-              defaultValue={data?.sensor.latitude}
-            />
-
-            <FormInput
-              register={register}
-              id="longitude"
-              label="Longitude"
-              errorMessage={errors.longitude?.message}
-              valueAsNumber
-              defaultValue={data?.sensor.longitude}
             />
 
             <SetSensorPositionMap

--- a/apps/web/src/pages/sensors/create.tsx
+++ b/apps/web/src/pages/sensors/create.tsx
@@ -31,7 +31,7 @@ const CreateSensorPage = ({
     latitude,
     longitude,
     error,
-  } = useSetSensorPositionMap();
+  } = useSetSensorPositionMap({});
 
   const {
     register,

--- a/apps/web/src/ui/Layout.tsx
+++ b/apps/web/src/ui/Layout.tsx
@@ -1,8 +1,6 @@
 import Head from "next/head";
 import { ReactNode } from "react";
 import Footer from "./Footer";
-import DesktopNavigation from "./navigation/DesktopNavigation";
-import MobileNavigation from "./navigation/MobileNavigation";
 import Navigation from "./navigation/Navigation";
 
 type LayoutProps = {

--- a/apps/web/src/ui/containers/SelectContainerDropdown.tsx
+++ b/apps/web/src/ui/containers/SelectContainerDropdown.tsx
@@ -18,8 +18,8 @@ import LoadingSpinner from "../LoadingSpinner";
 import { useRouter } from "next/router";
 
 type SelectContainerDropdownProps = {
-  containerId?: string;
-  setContainerId: Dispatch<SetStateAction<string | undefined>>;
+  containerId?: string | null;
+  setContainerId: Dispatch<SetStateAction<string | null | undefined>>;
   isLoading: boolean;
   data?: Container[];
 };
@@ -37,7 +37,7 @@ const SelectContainerDropdown = ({
 
   return (
     <div className="flex w-full flex-col items-center justify-start gap-y-2">
-      <Label htmlFor={containerId}>Container</Label>
+      <Label htmlFor={containerId || ""}>Container</Label>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="default">
@@ -61,7 +61,7 @@ const SelectContainerDropdown = ({
           {data && data.length > 0 && (
             <>
               <DropdownMenuRadioGroup
-                value={containerId}
+                value={containerId || undefined}
                 onValueChange={setContainerId}
               >
                 {data?.map((container) => (

--- a/packages/api/src/router/sensor.ts
+++ b/packages/api/src/router/sensor.ts
@@ -1,7 +1,6 @@
 import { getLocationFromLngLat } from "@acme/mapbox";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { Sensor } from "../lib/kysely";
 import { userIsMemberOfOrganization } from "../lib/clerk";
 import {
   SensorIdSchema,

--- a/packages/api/src/router/sensor.ts
+++ b/packages/api/src/router/sensor.ts
@@ -139,7 +139,7 @@ export const sensorRouter = router({
       );
       if (!isMemberOfOrganization) {
         throw new TRPCError({
-          code: "BAD_REQUEST",
+          code: "UNAUTHORIZED",
           message: "You are not part of this organization",
         });
       }
@@ -163,7 +163,7 @@ export const sensorRouter = router({
         sensor.organizationId === ctx.auth.organizationId;
       if (!sensorBelongsToOrganization) {
         throw new TRPCError({
-          code: "BAD_REQUEST",
+          code: "UNAUTHORIZED",
           message: "Your organization does not own this sensor",
         });
       }

--- a/packages/api/src/schemas/sensor.ts
+++ b/packages/api/src/schemas/sensor.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const SensorSchema = z.object({
   sensorId: z.string(),
-  collectionId: z.string().optional(),
+  collectionId: z.string(),
   name: z.string().min(1, { message: "Required" }),
   description: z.string(),
   latitude: z
@@ -13,7 +13,7 @@ export const SensorSchema = z.object({
     .number()
     .min(-180, { message: "Must be between -180 and 180" })
     .max(180, { message: "Must be between -180 and 180" }),
-  containerId: z.string(),
+  containerId: z.string().optional(),
 });
 export type Sensor = z.infer<typeof SensorSchema>;
 

--- a/packages/api/src/schemas/sensor.ts
+++ b/packages/api/src/schemas/sensor.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const SensorSchema = z.object({
   sensorId: z.string(),
-  collectionId: z.string(),
+  collectionId: z.string().optional(),
   name: z.string().min(1, { message: "Required" }),
   description: z.string(),
   latitude: z

--- a/packages/api/src/utils/sensor.ts
+++ b/packages/api/src/utils/sensor.ts
@@ -8,9 +8,11 @@ import axios from "axios";
  * @returns a boolean determining if the sensor belongs to the collection
  */
 export const sensorBelongsToCollection = async (
-  deviceId: string,
-  collectionId: string,
+  deviceId?: string,
+  collectionId?: string,
 ) => {
+  if (!deviceId || !collectionId) return false;
+
   return await axios
     .get(
       `https://api.lab5e.com/span/collections/${collectionId}/devices/${deviceId}`,


### PR DESCRIPTION
Closes: #64 

## Changelog

- Ensure all fields in update page are loaded correctly
- Load coordinates into map, not text fields

## How to test

- Lat and long should come from the map, not from input fields
- The marker on the map should be pinned on the sensor's location, not the user's current geolocation
- Set the container in dropdown based on current containerId
- Ensure that the update mutation still works after the change
- Ensure user can only update sensor's their organization owns
