### PR TITLE
fix: Map doesn't render when switching date interval

### DIFF
--- a/apps/web/src/schemas/index.ts
+++ b/apps/web/src/schemas/index.ts
@@ -7,3 +7,11 @@ export const SelectContainerQuerySchema = z.object({
   containerId: z.string(),
 });
 export type SelectContainerQuery = z.infer<typeof SelectContainerQuerySchema>;
+
+export const SelectDateIntervalQuerySchema = z.object({
+  startDate: z.string(),
+  endDate: z.string(),
+});
+export type SelectDateIntervalQuery = z.infer<
+  typeof SelectDateIntervalQuerySchema
+>;

--- a/apps/web/src/ui/navigation/DesktopNavigation.tsx
+++ b/apps/web/src/ui/navigation/DesktopNavigation.tsx
@@ -58,6 +58,7 @@ const DesktopNavigation = () => {
                         },
                       },
                     }}
+                    afterSignOutUrl="/"
                   />
                 </NavigationMenuItem>
               </div>

--- a/apps/web/src/ui/navigation/MobileNavigation.tsx
+++ b/apps/web/src/ui/navigation/MobileNavigation.tsx
@@ -81,6 +81,7 @@ const MobileNavigation = () => {
                         },
                       },
                     }}
+                    afterSignOutUrl="/"
                   />
                 </div>
               )}

--- a/packages/api/src/router/sensor.ts
+++ b/packages/api/src/router/sensor.ts
@@ -270,23 +270,16 @@ export const sensorRouter = router({
         });
       }
 
-      // Map data to array of objects with date and fill level using getFillLevel and store in array
-      // {
-      //   dateAndTime: dateAndTime,
-      //   fillLevel: fillLevel,
-      // },
-      const data = timeseries.map((data) => {
+      const result = timeseries.map((data) => {
         const datetime = data.time;
         const fillLevel = getFillLevel({ timeseries: data, container });
         return {
           datetime,
           fillLevel,
         };
-
-        // Return array of objects
       });
 
-      return data;
+      return result;
     }),
 
   getWithFillLevel: protectedProcedure


### PR DESCRIPTION
Closes: #85 

## Changelog

- Set date interval as URL state
- Reload page on change

## Important to note

The fix implemented here, and described below, is **very suboptimal**. This is a fix to add the intended feature but should be revisited in the future. The bottleneck here is Mapbox, being not very cooperative when React state in the application changes.

## How to test

- Go to page for one sensor
- Observe that no URL params are set
- Observe that the map is rendered
- Set a date interval
- Observe that the page is reloaded, and that URL params are set
- Observe that the date interval state is automatically set based on URL params

- Do this for all intervals and observe intended behavior
